### PR TITLE
Implemented command line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +75,22 @@ dependencies = [
  "num-traits",
  "time",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+dependencies = [
+ "atty",
+ "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
+ "textwrap",
 ]
 
 [[package]]
@@ -273,6 +300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +369,16 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -463,6 +506,15 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "parking_lot"
@@ -664,6 +716,7 @@ name = "sinuous"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "crossterm 0.21.0",
  "futures",
  "sonor",
@@ -723,6 +776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +791,21 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -970,6 +1044,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.44"
-crossterm ={ version = "0.21.0", features=["event-stream"] }
+clap = { version = "3.1", features=["cargo"] }
+crossterm = { version = "0.21.0", features=["event-stream"] }
 futures = "0.3.17"
 sonor = "1.1.0"
 tokio = { version = "1.12.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ To get debug logs, run `RUST_LOG="sinuous=debug" cargo run`. The logs can be fou
 - [ ] Display play/pause indicator as well as current play mode (shuffle+repeat)
 - [ ] Allow searching for tracks and modify the queue
 - [ ] Allow customizing colours
-- [ ] Allow specifying speaker to connect to as a command line argument
+- [x] Allow specifying speaker to connect to as a command line argument
 - [ ] Handle grouping of speakers

--- a/src/sonos.rs
+++ b/src/sonos.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use anyhow::Result;
 use futures::TryStreamExt;
 use sonor::{Speaker, Track, TrackInfo};
+use std::net::Ipv4Addr;
 use tokio::select;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
@@ -44,16 +45,16 @@ impl SonosService {
         }
     }
 
-    pub fn start(self) {
+    pub fn start(self, provided_devices: (Vec<Ipv4Addr>, Vec<String>)) {
         tokio::spawn(async move {
-            if let Err(err) = self.inner_loop().await {
+            if let Err(err) = self.inner_loop(provided_devices).await {
                 error!(%err, "Sonos error");
             }
         });
     }
 
-    async fn inner_loop(mut self) -> Result<()> {
-        self.speakers = get_speakers().await?;
+    async fn inner_loop(mut self, provided_devices: (Vec<Ipv4Addr>, Vec<String>)) -> Result<()> {
+        self.speakers = get_speakers(provided_devices).await?;
         // let speaker = get_speaker().await?;
         let mut ticker = tokio::time::interval(Duration::from_secs(1));
         debug!("Starting sonos loop");
@@ -154,10 +155,25 @@ impl SonosService {
         .ok_or(anyhow::anyhow!("Unable to fin a speaker on the network"))
 } */
 
-async fn get_speakers() -> Result<Vec<Speaker>> {
+async fn get_speakers(provided_devices: (Vec<Ipv4Addr>, Vec<String>)) -> Result<Vec<Speaker>> {
+    let mut speakers: Vec<Speaker> = vec![];
+    debug!("Connecting to provided speakers...");
+    for e in provided_devices.0.iter() {
+        if let Some(spk) = sonor::Speaker::from_ip(*e).await.unwrap_or(None) {
+            speakers.push(spk);
+        } else {
+            debug!("Not connecting to {} due to errors", e);
+        }
+    }
+    for e in provided_devices.1.iter() {
+        if let Some(device) = sonor::find(e, Duration::from_secs(2)).await? {
+            speakers.push(device);
+        } else {
+            debug!("Not connecting to {} due to errors", e);
+        }
+    }
     debug!("Discovering speakers...");
     let mut devices = sonor::discover(Duration::from_secs(2)).await?;
-    let mut speakers = vec![];
     while let Some(device) = devices.try_next().await? {
         speakers.push(device);
     }


### PR DESCRIPTION
One or multiple speakers can now be supplied via command line arguments, either by Ip or by roomname.
I only tested it with one speaker via ip, as I only own one Speaker and the name resolution and autodiscovery functions do not seem to work in my network. However the code seems to work fine as far as I can tell.

Usage example: `./sinous -d 127.0.0.1,0.0.0.1,bedroom`
(`./sinous --help` is also possible)